### PR TITLE
Add quality option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use failure::Error;
 mod normal;
 mod opt;
 mod playlist;
+mod stream;
 
 const VERSION: &str = "1.4.3";
 const HOST: &str = "http://nhl.freegamez.ga";
@@ -25,7 +26,7 @@ fn main() {
 
 /// Log any errors and causes
 pub fn log_error(e: &Error) {
-    eprintln!("ERROR: {}", e);
+    eprintln!("\nERROR: {}", e);
     for cause in e.iter_causes() {
         eprintln!("Caused by: {}", cause);
     }

--- a/src/normal.rs
+++ b/src/normal.rs
@@ -1,4 +1,9 @@
-use crate::{log_error, opt::Opt, BANNER, HOST};
+use crate::{
+    log_error,
+    opt::Opt,
+    stream::{get_master_m3u8, get_master_url, get_quality_url},
+    BANNER, HOST,
+};
 use async_std::task;
 use chrono::Local;
 use failure::{format_err, Error};
@@ -84,7 +89,15 @@ async fn process(opts: Opt) -> Result<(), Error> {
                     cdn,
                 );
 
-                println!("\n{}", url);
+                if let Some(ref quality) = opts.quality {
+                    let master_url = get_master_url(&url).await?;
+                    let master_m3u8 = get_master_m3u8(&master_url).await?;
+                    let quality_url = get_quality_url(&master_url, &master_m3u8, quality.clone())?;
+
+                    println!("\n{}", quality_url);
+                } else {
+                    println!("\n{}", url);
+                }
             }
         }
     }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -18,6 +18,11 @@ pub struct Opt {
     #[structopt(long, parse(try_from_str), default_value = Cdn::Akc.into())]
     /// Specify which CDN to use: 'akc' or 'l3c'
     pub cdn: Cdn,
+    #[structopt(long, parse(try_from_str))]
+    /// Specify a quality to use, otherwise stream will be adaptive.
+    ///
+    /// Must be one of: '720p60', '720p', '540p', '504p', '360p', '288p', '224p', '216p'
+    pub quality: Option<Quality>,
     #[structopt(long, parse(from_os_str))]
     /// Generate a .m3u playlist file for all games
     pub playlist_output: Option<PathBuf>,
@@ -72,6 +77,53 @@ impl FromStr for Cdn {
             "akc" => Ok(Cdn::Akc),
             "l3c" => Ok(Cdn::L3c),
             _ => bail!("Option must match 'akc' or 'l3c'"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Quality {
+    _720p60,
+    _720p,
+    _540p,
+    _504p,
+    _360p,
+    _288p,
+    _224p,
+    _216p,
+}
+
+impl From<Quality> for &str {
+    fn from(quality: Quality) -> &'static str {
+        match quality {
+            Quality::_720p60 => "72060",
+            Quality::_720p => "720",
+            Quality::_540p => "540",
+            Quality::_504p => "504",
+            Quality::_360p => "360",
+            Quality::_288p => "288",
+            Quality::_224p => "224",
+            Quality::_216p => "216",
+        }
+    }
+}
+
+impl FromStr for Quality {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Quality, Error> {
+        match s {
+            "720p60" => Ok(Quality::_720p60),
+            "720p" => Ok(Quality::_720p),
+            "540p" => Ok(Quality::_540p),
+            "504p" => Ok(Quality::_504p),
+            "360p" => Ok(Quality::_360p),
+            "288p" => Ok(Quality::_288p),
+            "224p" => Ok(Quality::_224p),
+            "216p" => Ok(Quality::_216p),
+            _ => bail!(
+                "\n\nMust be one of: '720p60', '720p', '540p', '504p', '360p', '288p', '224p', '216p'"
+            ),
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,86 @@
+use crate::opt::Quality;
+use failure::{bail, format_err, Error, ResultExt};
+use futures::AsyncReadExt;
+use http_client::{native::NativeClient, Body, HttpClient};
+
+pub async fn get_master_url(url: &str) -> Result<String, Error> {
+    let uri = url.parse::<http::Uri>().context("Failed to build URI")?;
+    let request = http::Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+
+    let client = NativeClient::default();
+    let resp = client.send(request).await?;
+
+    let mut body = resp.into_body();
+    let mut body_text = String::new();
+    body.read_to_string(&mut body_text)
+        .await
+        .context("Failed to read response body text")?;
+
+    if !&body_text[..].starts_with("https") {
+        bail!("Stream not available yet");
+    }
+
+    Ok(body_text)
+}
+
+pub async fn get_master_m3u8(url: &str) -> Result<String, Error> {
+    let uri = url.parse::<http::Uri>().context("Failed to build URI")?;
+    let request = http::Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+
+    let client = NativeClient::default();
+    let resp = client.send(request).await?;
+
+    let mut body = resp.into_body();
+    let mut body_text = String::new();
+    body.read_to_string(&mut body_text)
+        .await
+        .context("Failed to read response body text")?;
+
+    if body_text[..].starts_with("#EXTM3U") {
+        return Ok(body_text);
+    }
+
+    bail!("Failed to get master m3u8");
+}
+
+pub fn get_quality_url(
+    master_url: &str,
+    master_m3u8: &str,
+    quality: Quality,
+) -> Result<String, Error> {
+    let quality_str: &str = quality.clone().into();
+    let quality_check = format!("x{}", quality_str);
+
+    let mut quality_idx = None;
+    for (idx, line) in master_m3u8.lines().enumerate() {
+        if (quality == Quality::_720p60 && line.contains("FRAME-RATE"))
+            || (quality != Quality::_720p60 && line.contains(&quality_check))
+        {
+            quality_idx = Some(idx + 1);
+        }
+    }
+
+    if let Some(idx) = quality_idx {
+        let quality_line = master_m3u8
+            .lines()
+            .nth(idx)
+            .ok_or_else(|| format_err!("No stream found matching quality specified"))?;
+
+        let master_url_parts = master_url.rsplitn(2, '/').collect::<Vec<&str>>();
+        if master_url_parts.len() == 2 {
+            let quality_url = format!("{}/{}", master_url_parts[1], quality_line);
+
+            return Ok(quality_url);
+        }
+    }
+
+    bail!("No stream found matching quality specified");
+}


### PR DESCRIPTION
Satisfies #3 

Allows passing `--quality` option to get specific stream link for that
applicable quality. Master m3u8 file is downloaded and parsed to build
the correct url for that quality. Not all qualities exist for every
stream, this will error out in normal mode, but silently fail / not add
stream in playlist / xmltv mode.