### PR TITLE
pass quality to streamlink

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -33,12 +33,12 @@ async fn process(opts: Opt) -> Result<(), Error> {
 
     let mut lazy_stream = LazyStream::new(&opts).await?;
 
-    if let Some(quality) = &opts.quality {
+    if let Some(quality) = opts.quality {
         lazy_stream
-            .resolve_with_quality_link(&opts.cdn, quality)
+            .resolve_with_quality_link(opts.cdn, quality)
             .await;
     } else {
-        lazy_stream.resolve_with_master_link(&opts.cdn).await;
+        lazy_stream.resolve_with_master_link(opts.cdn).await;
     }
 
     let games = lazy_stream.games();
@@ -54,8 +54,8 @@ async fn process(opts: Opt) -> Result<(), Error> {
                 create_playlist(
                     path.clone(),
                     games.clone(),
-                    &opts.cdn,
-                    &opts.quality,
+                    opts.cdn,
+                    opts.quality,
                     true,
                     start_channel,
                     Some(&channel_prefix),
@@ -66,8 +66,8 @@ async fn process(opts: Opt) -> Result<(), Error> {
                 create_xmltv(
                     path,
                     games,
-                    &opts.cdn,
-                    &opts.quality,
+                    opts.cdn,
+                    opts.quality,
                     start_channel,
                     opts.sport,
                     &channel_prefix,
@@ -76,7 +76,7 @@ async fn process(opts: Opt) -> Result<(), Error> {
             }
             GenerateCommand::Playlist { file } => {
                 let path = file.with_extension("m3u");
-                create_playlist(path, games, &opts.cdn, &opts.quality, false, 1000, None).await?;
+                create_playlist(path, games, opts.cdn, opts.quality, false, 1000, None).await?;
             }
         }
     }
@@ -87,8 +87,8 @@ async fn process(opts: Opt) -> Result<(), Error> {
 async fn create_playlist(
     path: PathBuf,
     mut games: Vec<Game>,
-    cdn: &Cdn,
-    quality: &Option<Quality>,
+    cdn: Cdn,
+    quality: Option<Quality>,
     is_xmltv: bool,
     start_channel: u32,
     channel_prefix: Option<&str>,
@@ -146,8 +146,8 @@ async fn create_playlist(
 async fn create_xmltv(
     path: PathBuf,
     mut games: Vec<Game>,
-    cdn: &Cdn,
-    quality: &Option<Quality>,
+    cdn: Cdn,
+    quality: Option<Quality>,
     start_channel: u32,
     sport: Sport,
     channel_prefix: &str,

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -278,7 +278,7 @@ fn parse_date(src: &str) -> Result<NaiveDate, ParseError> {
     NaiveDate::parse_from_str(&s, "%Y%m%d")
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Cdn {
     Akc,
     L3c,
@@ -312,7 +312,7 @@ impl std::fmt::Display for Cdn {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Quality {
     _720p60,
     _720p,
@@ -366,7 +366,22 @@ impl std::fmt::Display for Quality {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
+impl Quality {
+    pub fn to_streamlink_quality<'a>(self) -> &'a str {
+        match self {
+            Quality::_720p60 => "720p_alt",
+            Quality::_720p => "720p",
+            Quality::_540p => "540p",
+            Quality::_504p => "504p",
+            Quality::_360p => "360p",
+            Quality::_288p => "288p",
+            Quality::_224p => "224p",
+            Quality::_216p => "216p",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub enum FeedType {
     Home,
     Away,

--- a/src/select.rs
+++ b/src/select.rs
@@ -81,12 +81,12 @@ pub async fn process(opts: &Opt, need_return: bool) -> Result<(Game, Stream), Er
     let feed_choice = &feeds[(feed_choice - 1)];
     let mut stream = streams.remove(feed_choice).unwrap();
 
-    let host_link = stream.host_link(&lazy_stream.opts.cdn);
+    let host_link = stream.host_link(lazy_stream.opts.cdn);
 
-    let cdn = &lazy_stream.opts.cdn;
+    let cdn = lazy_stream.opts.cdn;
     if !need_return {
         println!();
-        if let Some(ref quality) = lazy_stream.opts.quality {
+        if let Some(quality) = lazy_stream.opts.quality {
             let quality_link = stream.quality_link(cdn, quality).await?;
             println!("{}", quality_link);
         } else if resolve {


### PR DESCRIPTION
if 720p60 is chosen, we use bitrate as the key and choose the best
stream, as it'll have the highest bitrate. If 720p60 isn't available,
and since best is used, it'll default to the next highest bitrate. All
other quality settings, if chosen, match exactly. So if it isn't found,
it'll fail. If no quality is chosen, best is always used.