### PR TITLE
add shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # LazyStream
 [![Build Status](https://dev.azure.com/tarkah/lazystream/_apis/build/status/tarkah.lazystream?branchName=master)](https://dev.azure.com/tarkah/lazystream/_build/latest?definitionId=11&branchName=master)
 
+
+  - [Overview](#overview)
+  - [Shell Completions](#shell-completions)
+
+## Overview
 Easily get LazyMan stream links, output directly or to m3u / xmltv formats. Streams can also be recorded or casted.
 
 - Supports both NHL and MLB games. Use `--sport` option to specify `mlb` or `nhl` [default: nhl]
@@ -74,4 +79,12 @@ Pick a stream...
 >>> 2
 
 http://nhl.freegamez.ga/getM3U8.php?league=nhl&date=2019-12-05&id=70395003&cdn=akc
+```
+
+## Shell Completions
+
+Shell completions can be generated for Bash, Fish and Zsh. Target shell and target directory must be supplied.
+
+```
+lazystream completions bash ~/.local/share/bash-completion/completions/
 ```

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,18 @@
+use crate::opt::{Command, Opt};
+
+use structopt::{clap::Shell, StructOpt};
+
+pub fn run(opts: Opt) {
+    if let Command::Completions { shell, target } = opts.command {
+        let _shell = match shell.as_str() {
+            "bash" => Shell::Bash,
+            "fish" => Shell::Fish,
+            "zsh" => Shell::Zsh,
+            _ => Shell::Bash,
+        };
+
+        Opt::clap().gen_completions(env!("CARGO_PKG_NAME"), _shell, &target);
+
+        println!("{}lazystream.{} saved!", target.display(), shell);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use colored::Colorize;
 use failure::Error;
 
 mod api;
+mod completions;
 mod generate;
 mod opt;
 mod select;
@@ -27,6 +28,7 @@ fn main() {
         OutputType::Play(opts) => crate::streamlink::run(opts),
         OutputType::Record(opts) => crate::streamlink::run(opts),
         OutputType::Cast(opts) => crate::streamlink::run(opts),
+        OutputType::Completions(opts) => crate::completions::run(opts),
     }
 }
 


### PR DESCRIPTION
`completions` subcommand allows user to output a completions file for
the supplied SHELL arg to TARGET dir