### PR TITLE
Specify modified segment key uri with streamlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dns-parser"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +571,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1347,6 +1358,7 @@ dependencies = [
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum curl 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "06aa71e9208a54def20792d877bc663d6aae0732b9852e612c4a933177c31283"
 "checksum curl-sys 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)" = "0c38ca47d60b86d0cc9d42caa90a0885669c2abc9791f871c81f58cdf39e979b"
+"checksum dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
 "checksum dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ colored = "1.9"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+dns-lookup = "1.0"
 
 futures = "0.3.1"
 async-std = { version = "1.0", features = ['unstable'] }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -390,7 +390,7 @@ impl Stream {
         if self.quality_link.is_none() {
             if self.master_m3u8.is_none() {
                 if let Ok(master_link) = self.master_link(cdn).await {
-                    match get_master_m3u8(&master_link).await {
+                    match get_m3u8(&master_link).await {
                         Err(e) => {
                             self.quality_link = Some(None);
                             bail!(e);
@@ -454,7 +454,7 @@ async fn get_master_link(url: &str) -> Result<String, Error> {
     Ok(body_text)
 }
 
-async fn get_master_m3u8(url: &str) -> Result<String, Error> {
+pub async fn get_m3u8(url: &str) -> Result<String, Error> {
     let uri = url.parse::<http::Uri>().context("Failed to build URI")?;
     let request = http::Request::builder()
         .method("GET")
@@ -510,4 +510,32 @@ fn get_quality_link(
     }
 
     bail!("No stream found matching quality specified");
+}
+
+pub async fn get_segment_key_uri(master_link: &str, master_m3u8: &str) -> Result<http::Uri, Error> {
+    // Get first .m3u8 stream match, we will extract the segment key from this file
+    let stream_regex = regex::Regex::new(r"(?m)^.*\.m3u8$").unwrap();
+    let stream_match = stream_regex.find(master_m3u8);
+
+    if let Some(_match) = stream_match {
+        let master_link_parts = master_link.rsplitn(2, '/').collect::<Vec<&str>>();
+        if master_link_parts.len() == 2 {
+            let stream_link = format!("{}/{}", master_link_parts[1], _match.as_str());
+
+            let stream_m3u8 = get_m3u8(&stream_link).await?;
+
+            // segment key url should be the only valid url in the file, get first match
+            let key_regex = regex::Regex::new(r"(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?").unwrap();
+            let key_match = key_regex.find(&stream_m3u8);
+
+            if let Some(_match) = key_match {
+                let uri = http::Uri::from_str(_match.as_str())
+                    .context("Could not get segment key uri")?;
+
+                return Ok(uri);
+            }
+        }
+    }
+
+    bail!("Could not get segment key uri");
 }

--- a/src/streamlink.rs
+++ b/src/streamlink.rs
@@ -6,12 +6,20 @@ use crate::{
 use async_std::{process, task};
 use chrono::Local;
 use failure::{bail, format_err, Error, ResultExt};
-use http::Uri;
+use http::{uri::PathAndQuery, Uri};
 use mdns::RecordKind;
 use read_input::prelude::*;
 use std::{
-    collections::HashMap, io::Write, net::Ipv4Addr, path::PathBuf, process::Stdio, time::Duration,
+    collections::HashMap,
+    io::Write,
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+    process::Stdio,
+    time::Duration,
 };
+
+/// Fallback for when DNS lookup fails
+const FALLBACK_KEY_SEGMENT_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(165, 22, 201, 101));
 
 pub fn run(opts: Opt) {
     task::block_on(async {
@@ -44,6 +52,13 @@ async fn process(opts: Opt) -> Result<(), Error> {
     }
     let link = stream.master_link(opts.cdn).await?;
 
+    let segment_key_uri = {
+        match crate::stream::get_m3u8(&link).await {
+            Ok(master_m3u8) => crate::stream::get_segment_key_uri(&link, &master_m3u8).await,
+            Err(e) => Err(e),
+        }
+    };
+
     let args = StreamlinkArgs {
         link,
         game,
@@ -53,6 +68,7 @@ async fn process(opts: Opt) -> Result<(), Error> {
         proxy,
         offset,
         quality,
+        segment_key_uri,
     };
 
     task::spawn_blocking(move || streamlink(args)).await?;
@@ -370,6 +386,7 @@ struct StreamlinkArgs {
     proxy: Option<Uri>,
     offset: Option<String>,
     quality: Option<Quality>,
+    segment_key_uri: Result<Uri, Error>,
 }
 
 fn streamlink(mut args: StreamlinkArgs) -> Result<(), Error> {
@@ -425,6 +442,46 @@ fn streamlink(mut args: StreamlinkArgs) -> Result<(), Error> {
          Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko \
          Chrome/59.0.3071.115 Safari/537.36",
     ];
+
+    // If we couldn't get the actual segment key uri or building it with the
+    // "proxied" IP fails for some reason, print error but still try to connect
+    // (in case user has hosts file updated)
+    let mut _uri = String::new();
+    match args.segment_key_uri {
+        Ok(segment_key_uri) => {
+            let host_lookup = dns_lookup::lookup_host("freegamez.ga")?;
+            let proxied_key_ip = host_lookup.get(0).unwrap_or(&FALLBACK_KEY_SEGMENT_IP);
+
+            let proxied_key_uri = http::uri::Builder::new()
+                .scheme(segment_key_uri.scheme_str().unwrap_or(""))
+                .authority(proxied_key_ip.to_string().as_str())
+                .path_and_query(
+                    segment_key_uri
+                        .path_and_query()
+                        .unwrap_or(&PathAndQuery::from_static(""))
+                        .as_str(),
+                )
+                .build()
+                .ok();
+
+            if let Some(uri) = proxied_key_uri {
+                _uri = uri.to_string();
+
+                println!("[lazystream][info] Proxying segment key url to: {}", _uri);
+
+                command_args.push("--hls-segment-key-uri");
+                command_args.push(_uri.as_str());
+            } else {
+                println!("[lazystream][warning] Could not proxy segment key url");
+            }
+        }
+        Err(e) => {
+            println!(
+                "[lazystream][warning] Could not proxy segment key url: {}",
+                e
+            );
+        }
+    }
 
     if args.restart {
         command_args.push("--hls-live-restart");


### PR DESCRIPTION
Streamlink has option `--hls-segment-key-uri`. We can extract the
segment key uri from the .m3u file and replace the host with the IP for
freegamez.ga. With this, user no longer needs to update their hosts file
since Streamlink will request the segment key directly from the
"proxied" IP