### PR TITLE
fix mlb deser bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "stats-api 0.1.0 (git+https://github.com/tarkah/stats-api?rev=1d8f53d940a5cee741a8e5b744ec4e5573b835fb)",
+ "stats-api 0.1.0 (git+https://github.com/tarkah/stats-api?rev=6c62f386c16eb06db7562954f3890e1b7713cf74)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1022,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "stats-api"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/stats-api?rev=1d8f53d940a5cee741a8e5b744ec4e5573b835fb#1d8f53d940a5cee741a8e5b744ec4e5573b835fb"
+source = "git+https://github.com/tarkah/stats-api?rev=6c62f386c16eb06db7562954f3890e1b7713cf74#6c62f386c16eb06db7562954f3890e1b7713cf74"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1436,7 +1436,7 @@ dependencies = [
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
-"checksum stats-api 0.1.0 (git+https://github.com/tarkah/stats-api?rev=1d8f53d940a5cee741a8e5b744ec4e5573b835fb)" = "<none>"
+"checksum stats-api 0.1.0 (git+https://github.com/tarkah/stats-api?rev=6c62f386c16eb06db7562954f3890e1b7713cf74)" = "<none>"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a1bcbed7d48956fcbb5d80c6b95aedb553513de0a1b451ea92679d999c010e98"
 "checksum structopt-derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["tarkah <admin@tarkah.dev>"]
 edition = "2018"
 
 [dependencies]
-stats-api = { git = "https://github.com/tarkah/stats-api", rev = "1d8f53d940a5cee741a8e5b744ec4e5573b835fb" }
+stats-api = { git = "https://github.com/tarkah/stats-api", rev = "6c62f386c16eb06db7562954f3890e1b7713cf74" }
 
 failure = "0.1"
 chrono = "0.4"

--- a/src/api/model.rs
+++ b/src/api/model.rs
@@ -8,6 +8,7 @@ pub struct Team {
     pub name: String,
     pub link: String,
     pub abbreviation: String,
+    #[serde(default)]
     pub team_name: String,
     pub location_name: Option<String>,
     pub first_year_of_play: Option<String>,


### PR DESCRIPTION
some teams don't have a teamName. Use default "" string, this should
only be an issue for non-MLB teams.

fixes #41 