### PR TITLE
Sort games for consistent output

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -67,8 +67,8 @@ pub async fn process(opts: &Opt, need_return: bool) -> Result<(Game, Stream), Er
 
     println!("\nPick a stream...\n");
 
-    let mut feeds: Vec<FeedType> = streams.clone().into_iter().map(|(k, _)| k).collect();
-    feeds.sort();
+    let feeds: Vec<FeedType> = streams.clone().into_iter().map(|(k, _)| k).collect();
+
     for (idx, feed_type) in feeds.iter().enumerate() {
         println!("{}) {}", idx + 1, feed_type);
     }


### PR DESCRIPTION
The API changes how games are sorted in the response based on the game
status (In Progress, Scheduled, Final). Sort the games by their datetime
then away team name for consistent output in the Select and Generate
outputs. Also use BTreeMap instead of Hashmap for the games streams so
it retains its original order.