### PR TITLE
use quality link for streamlink

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -493,6 +493,7 @@ fn get_quality_link(
             || (quality != Quality::_720p60 && line.contains(&quality_check))
         {
             quality_idx = Some(idx + 1);
+            break;
         }
     }
 


### PR DESCRIPTION
use actual quality link when quality is specified instead of having
streamlink negotiate quality, since it keeps things adaptive.

fixes #48 