### PR TITLE
fix for todays schedule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "stats-api"
 version = "0.1.0"
-source = "git+https://github.com/tarkah/stats-api?rev=d918b971b235f3b06b597bd09b28511d35cbbbee#d918b971b235f3b06b597bd09b28511d35cbbbee"
+source = "git+https://github.com/tarkah/stats-api?rev=d1834a7cb76da175b6d8f7505ef239f1eff0203e#d1834a7cb76da175b6d8f7505ef239f1eff0203e"
 dependencies = [
  "chrono",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["tarkah <admin@tarkah.dev>"]
 edition = "2018"
 
 [dependencies]
-stats-api = { git = "https://github.com/tarkah/stats-api", rev = "d918b971b235f3b06b597bd09b28511d35cbbbee" }
+stats-api = { git = "https://github.com/tarkah/stats-api", rev = "d1834a7cb76da175b6d8f7505ef239f1eff0203e" }
 
 failure = "0.1"
 chrono = "0.4"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -17,6 +17,22 @@ impl Client {
         Client { mlb, nhl, sport }
     }
 
+    pub async fn get_todays_schedule(&self) -> Result<Schedule, Error> {
+        let serialized = match &self.sport {
+            Sport::Mlb => {
+                let schedule = self.mlb.get_todays_schedule().await?;
+                serde_json::to_vec(&schedule)?
+            }
+            Sport::Nhl => {
+                let schedule = self.nhl.get_todays_schedule().await?;
+                serde_json::to_vec(&schedule)?
+            }
+        };
+
+        let schedule = serde_json::from_slice(&serialized)?;
+        Ok(schedule)
+    }
+
     pub async fn get_schedule_for(&self, date: chrono::NaiveDate) -> Result<Schedule, Error> {
         let serialized = match &self.sport {
             Sport::Mlb => {


### PR DESCRIPTION
resolves #57

Don't pass a date to the API for "todays" schedule to always resolve to "todays"  game regardless of timezone someone is in