### PR TITLE
Feature/host cli option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
         OutputType::Record(opts) => crate::streamlink::run(opts),
         OutputType::Cast(opts) => crate::streamlink::run(opts),
         OutputType::Completions(opts) => crate::completions::run(opts),
+        OutputType::Host(host) => println!("{}", host),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ mod stream;
 mod streamlink;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const HOST: &str = "http://freesports.ddns.net";
 const BANNER: &str = r#"
  |        \   __  /\ \   / ___|__ __|  _ \  ____|    \     \  | 
  |       _ \     /  \   /\___ \   |   |   | __|     _ \   |\/ | 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -5,6 +5,8 @@ use isahc::http::Uri;
 use std::{path::PathBuf, str::FromStr};
 use structopt::{clap::AppSettings::DeriveDisplayOrder, StructOpt};
 
+const HOST: &str = "http://freesports.ddns.net";
+
 pub fn parse_opts() -> OutputType {
     let opts = Opt::from_args();
 
@@ -44,6 +46,9 @@ pub struct Opt {
     #[structopt(long, global = true)]
     /// Disables unavailable stream retry for `play`, `record`, and `cast` commands. Program will exit instead.
     pub disable_retry: bool,
+    #[structopt(long, global = true, default_value = HOST)]
+    /// Specify a host
+    pub host: String,
 }
 
 #[derive(StructOpt, Debug, PartialEq, Clone)]

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -17,6 +17,7 @@ pub fn parse_opts() -> OutputType {
         Command::Record { .. } => OutputType::Record(opts),
         Command::Cast { .. } => OutputType::Cast(opts),
         Command::Completions { .. } => OutputType::Completions(opts),
+        Command::Host { .. } => OutputType::Host(opts.host),
     }
 }
 
@@ -104,6 +105,9 @@ pub enum Command {
         /// Target directory to save completions
         target: PathBuf,
     },
+    #[structopt(usage = "lazystream host [OPTIONS]")]
+    /// Print the host used by 'lazystream'
+    Host,
 }
 
 #[derive(StructOpt, Debug, PartialEq, Clone)]
@@ -326,6 +330,7 @@ pub enum OutputType {
     Record(Opt),
     Cast(Opt),
     Completions(Opt),
+    Host(String),
 }
 
 fn parse_date(src: &str) -> Result<NaiveDate, ParseError> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,7 +6,6 @@ use crate::{
         },
     },
     opt::{Cdn, FeedType, Opt, Quality, Sport},
-    HOST,
 };
 use chrono::{DateTime, NaiveDate, Utc};
 use failure::{bail, format_err, Error, ResultExt};
@@ -58,6 +57,7 @@ impl LazyStream {
 
             let game = Game::new(
                 opts.sport,
+                opts.host.clone(),
                 game_pk,
                 game_date,
                 date,
@@ -137,6 +137,7 @@ impl LazyStream {
 #[derive(Clone)]
 pub struct Game {
     sport: Sport,
+    host: String,
     pub game_pk: u64,
     pub game_date: DateTime<Utc>,
     pub selected_date: NaiveDate,
@@ -149,6 +150,7 @@ pub struct Game {
 impl Game {
     fn new(
         sport: Sport,
+        host: String,
         game_pk: u64,
         game_date: DateTime<Utc>,
         selected_date: NaiveDate,
@@ -157,6 +159,7 @@ impl Game {
     ) -> Self {
         Game {
             sport,
+            host,
             game_pk,
             game_date,
             selected_date,
@@ -190,6 +193,7 @@ impl Game {
 
                                     let stream = Stream::new(
                                         id,
+                                        self.host.clone(),
                                         self.sport,
                                         feed_type,
                                         self.game_date,
@@ -348,6 +352,7 @@ impl Game {
 #[allow(clippy::option_option)]
 pub struct Stream {
     id: String,
+    host: String,
     sport: Sport,
     pub feed_type: FeedType,
     game_date: DateTime<Utc>,
@@ -360,6 +365,7 @@ pub struct Stream {
 impl Stream {
     fn new(
         id: String,
+        host: String,
         sport: Sport,
         feed_type: FeedType,
         game_date: DateTime<Utc>,
@@ -367,6 +373,7 @@ impl Stream {
     ) -> Self {
         Stream {
             id,
+            host,
             sport,
             feed_type,
             game_date,
@@ -380,7 +387,7 @@ impl Stream {
     pub fn host_link(&self, cdn: Cdn) -> String {
         format!(
             "{}/getM3U8.php?league={}&date={}&id={}&cdn={}",
-            HOST,
+            self.host,
             self.sport,
             self.selected_date.format("%Y-%m-%d"),
             self.id,


### PR DESCRIPTION
Resolves #86 

Adds 2 new cli options:

- Global option `--host <host>` overrides the host used by lazystream and can be set to any URL.
- Subcommand `lazystream host` returns the host used by lazystream